### PR TITLE
feat(server): validated env, health check, OpenAPI and API hardening

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,34 @@
+# Copie para `.env` e ajuste os valores.
+
+NODE_ENV=development
+PORT=3000
+HOST_PORT=3001
+
+PAGE_SIZE=20
+LOG_LEVEL=info
+CORS_ORIGIN=http://localhost:3002
+
+# Opcional: SSL para provedores como Neon
+# DB_USE_SSL=true
+
+# Limites de pool e timeout de consulta (ms)
+DB_POOL_MAX=10
+DB_STATEMENT_TIMEOUT_MS=30000
+
+DB_FURNAS_HOST=localhost
+DB_FURNAS_PORT=5433
+DB_FURNAS_USER=postgres
+DB_FURNAS_PASSWORD=postgres
+DB_FURNAS_NAME=bdfurnas-campanha
+
+DB_SIMA_HOST=localhost
+DB_SIMA_PORT=5434
+DB_SIMA_USER=postgres
+DB_SIMA_PASSWORD=postgres
+DB_SIMA_NAME=bdsima
+
+DB_BALCAR_HOST=localhost
+DB_BALCAR_PORT=5435
+DB_BALCAR_USER=postgres
+DB_BALCAR_PASSWORD=postgres
+DB_BALCAR_NAME=bdbalcar-campanha

--- a/server/.prettierignore
+++ b/server/.prettierignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+package-lock.json

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5,16 +5,22 @@
   "packages": {
     "": {
       "dependencies": {
+        "@turf/turf": "^7.3.4",
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.3.2",
+        "helmet": "^8.1.0",
         "pg": "^8.16.3",
-        "winston": "^3.17.0"
+        "swagger-ui-express": "^5.0.1",
+        "winston": "^3.17.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/pg": "^8.15.5",
+        "@types/swagger-ui-express": "^4.1.8",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
         "@typescript-eslint/parser": "^8.43.0",
         "eslint": "^9.35.0",
@@ -330,6 +336,13 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -357,6 +370,2047 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@turf/along": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-7.3.4.tgz",
+      "integrity": "sha512-PvIoXin0I1t3nRwJz7uqR6fsxDMqdGwJq90qGOeqkNwlZqlF+5o2wKHPwYwi0RXZhLvxRP5qlbNIvV8ADdbWxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/angle": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/angle/-/angle-7.3.4.tgz",
+      "integrity": "sha512-235JAfbrNMjHQXQfd/p+fYnlfCHsQsKHda5Eeyc+/jIY0s5mKvhcxgFaOEnigA2q1n+PrVOExs3BViGTKnWhAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/area": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.4.tgz",
+      "integrity": "sha512-UEQQFw2XwHpozSBAMEtZI3jDsAad4NnHL/poF7/S6zeDCjEBCkt3MYd6DSGH/cvgcOozxH/ky3/rIVSMZdx4vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.4.tgz",
+      "integrity": "sha512-D5ErVWtfQbEPh11yzI69uxqrcJmbPU/9Y59f1uTapgwAwQHQztDWgsYpnL3ns8r1GmPWLP8sGJLVTIk2TZSiYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-clip": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-7.3.4.tgz",
+      "integrity": "sha512-HCn0q/WPVEE9Dztg7tCvClOPrrh9MoxNUk73byHvcZLBcvziN6F84f/ZbFcbQSh8hgOeVMs/keeqWMqsICcNLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-7.3.4.tgz",
+      "integrity": "sha512-XCDYQwCA41Bum3R1xX0Na1nR4ozoe/pCYy5bxqrzyMs87kPJUIfBrD5IWxjnZyLqFpfEpolMHJz5ed1uA2PanQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bearing": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.3.4.tgz",
+      "integrity": "sha512-zvFjapyFaOrM8nBtAND7f4yb0BJV0jyj6cyoXyTYqLY+3Hn0eHgL0M8lwxDLbTom5KfqYDHDVDQC3+VSfypoEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bezier-spline": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-7.3.4.tgz",
+      "integrity": "sha512-+iDUeiBKByIs/6K5WW8pG6IDxrRLJHFLM80zSpzk2xBtgy3mq36NZwwt67Pu7EJAkc9GUXKIm9SkspoKue9aYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-7.3.4.tgz",
+      "integrity": "sha512-X/O+u/OsoJ99mujhlqviuB7HX0tdJ5931TBjNSseps43XtROVuB5PwBDgwKfu5lY1B4DSGAxbbxJ795RmPnguQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-concave": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-concave/-/boolean-concave-7.3.4.tgz",
+      "integrity": "sha512-SHuAzjqaAes6ELDZcN/FKZWCQZsqwYv3gMosoLRFWTwKyBQe8i29e4y6XnXakDr1uklVUeRRcdhZ5oKtX9ABPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.3.4.tgz",
+      "integrity": "sha512-AJMGbtC6HiXgHvq0RNlTfsDB58Qf9Js45MP/APbhGTH4AiLZ8VMDISywVFNd7qN6oppNlDd3xApVR28+ti8bNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-split": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-crosses": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-7.3.4.tgz",
+      "integrity": "sha512-v/U3SuGdkexfLTMhho6Vj0OjqPUeYdThxp8zggGJ1VHow27fvLLez0DjUR3AftHjjHM6bRzZoNsu2qUlEe5hjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-equal": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/polygon-to-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-disjoint": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-7.3.4.tgz",
+      "integrity": "sha512-Dl4O27ygi2NqskGQuvSlDLJYlJ2SPkHb3A9T/v6eAudjlMiKdEY6bMxKUfU5y+Px1WiCZxd+9rXGXJgGC3WiQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/polygon-to-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-equal": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-7.3.4.tgz",
+      "integrity": "sha512-AhWqe7D1o0wp3d3QQRSqgWDI8s1JfTFKFe9rU5mrSxYPGlmaQsJC07RCaYfFiGym9lACd1lxBJiPidCbLaPOfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-intersects": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-7.3.4.tgz",
+      "integrity": "sha512-sxi41NXkb5hrJgOvpm32hyBLhW8fem0vn2XxR4+jyRg1rM/v3ziF10/VqC9KDZuDNZkt9JjL9B0825Cf7AN6Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-disjoint": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-overlap": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-7.3.4.tgz",
+      "integrity": "sha512-Q3dlswIuqffSiMfln7xa36YDnN1TWtERMF/155rzjglm4NTUG/6S+gNsb8s6qpLjc+hN6btCq1ZjxAWurPf8Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/line-overlap": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-parallel": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-7.3.4.tgz",
+      "integrity": "sha512-sTNMqsUkLPnSJEqc2IZ5ig3nHRoubyOH2HW1LILqOybCJI630FEM9UoYP1pZniF5nwTyCjQWnXA1FxusVILuFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.4.tgz",
+      "integrity": "sha512-v/4hfyY90Vz9cDgs2GwjQf+Lft8o7mNCLJOTz/iv8SHAIgMMX0czEoIaNVOJr7tBqPqwin1CGwsncrkf5C9n8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.3.4.tgz",
+      "integrity": "sha512-70gm5x6YQOZKcw0b/O4jjMwVWnFj+Zb6TXozLgZFDZShc8pgTQtZku7K+HKZ7Eya+7usHIB4IimZauomOMa+iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-touches": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-touches/-/boolean-touches-7.3.4.tgz",
+      "integrity": "sha512-XOwhjc0oCWhnBUB+l4drpXcg7mkNXPX3SuSz/Xv7gvLH/yRrBwzVGllzK1AHlGU9BVkGVBJIZGYX7jgTM681NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-valid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-valid/-/boolean-valid-7.3.4.tgz",
+      "integrity": "sha512-P6M9BtRvzFF2N5g+1/DTIbYGpEbwQ2sv/Pw+uj11P3NYAA9VE8mvrxFYf+CowFdSfY6bY4ejhuqKhrTmAMv7wA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-crosses": "7.3.4",
+        "@turf/boolean-disjoint": "7.3.4",
+        "@turf/boolean-overlap": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "geojson-polygon-self-intersections": "^1.2.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-within": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-7.3.4.tgz",
+      "integrity": "sha512-eLgi803gz0KcYkyxnnqnz9Vd6tw2/0eAExe/Rq8sO0dqypaSiomSumxjqu89d/yo24Qz8gW7c0kJ6YihNbMYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-split": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-7.3.4.tgz",
+      "integrity": "sha512-MVOCBDuOl3KGDsh2stW12RmiFaFeSkVjeUbZ+ADUtIVnv+jlFsmjBpFtsEw8s9YQn5g0667QppOshm0FBHA57Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/jsts": "^2.7.1",
+        "@turf/meta": "7.3.4",
+        "@turf/projection": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "d3-geo": "1.7.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.3.4.tgz",
+      "integrity": "sha512-4SsLMDHWthXbyIHsczgFCo4fx+8tC8w2+B5HdEuY+P+cSOOL4T+6QQzd7WWjuN/Y3ndowFssUmwRrvXuwVRxQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-mean": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-7.3.4.tgz",
+      "integrity": "sha512-6foVk5HLjlSPr48EI686Eis6/bYrJiHjKQlwY/7YlJc1uDitsIjPw2LjUCGIUZDEd6PdNUgg1+LgI7klXYvW3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-median": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-7.3.4.tgz",
+      "integrity": "sha512-Bz6rDr0plQOGSXgT3X3t941pYd44a5vIY8OEt4Y11H1BsgpmzFc6g7L5mr7FXW/uiYGxOewAfNcVUYUdJf9kMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/center-mean": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-of-mass": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-7.3.4.tgz",
+      "integrity": "sha512-mOSupDF5qxQTA/kOWYletHcBJQ3S2gVl/IRgrBH/YY9yiFq6UGRpZ0sNcIML4H06u/1DY/jqqG+d1nc/1yIA6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.4",
+        "@turf/convex": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.4.tgz",
+      "integrity": "sha512-6c3kyTSKBrmiPMe75UkHw6MgedroZ6eR5usEvdlDhXgA3MudFPXIZkMFmMd1h9XeJ9xFfkmq+HPCdF0cOzvztA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/circle": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.3.4.tgz",
+      "integrity": "sha512-6ccr5iT51/XONF+pbpkqoRxKX4ZVWLubXb1frGCnClv2suo1UIY9SIlINNctVDupXd2P9PpqZCbrXATrcrokPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clean-coords": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-7.3.4.tgz",
+      "integrity": "sha512-S61aJXLvPN/uZHtjzmJbLv7xhi28Sq3PshCIZSvno4Mo45bvl79Vg4aZskrG05AaSSbipplqfH+MZrkW9Xboeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.4.tgz",
+      "integrity": "sha512-pwQ+RyQw986uu7IulY/18NRAebwZZScb084bvVqVkTrllwLSv4oVBqUxmUMiwtp+PNdiRGRFOvNyZqtRsiD+Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-7.3.4.tgz",
+      "integrity": "sha512-+zoSyiF0LilXy4Tr0/lC7IgqbTMZZ2wwP3iSrqre58b61pUtdhCnBcjA2r8FkcW7z3GMbGf5XkIWhO+b+vDSsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-dbscan": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-7.3.4.tgz",
+      "integrity": "sha512-RkuXf767Shk0AfY+fh0PASVw8YR4H8zYR7XQrCgWd/bCuh6CXs7rWZ6UTLu/PiA6y6WsIhyAQv4LhNH5kCzpbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "@types/geokdbush": "^1.1.5",
+        "geokdbush": "^2.0.1",
+        "kdbush": "^4.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-kmeans": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-7.3.4.tgz",
+      "integrity": "sha512-89mlwhcb+vyZAKX0eBa3LQ8VyIKLayrzJpKGb90sEkIu0hDua9JCE+zlbaPoUAvAqflEiX+poFFuh7pngtsBMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "skmeans": "0.9.7",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/collect": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-7.3.4.tgz",
+      "integrity": "sha512-fG28oDZK4HCXC/AhF0pmHKLtI9DWwdJr/ktuWolrqzA5b1G7eawrXwDu8B5I3sXhdWonNRMcuLbIuz+XQscHKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/combine": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-7.3.4.tgz",
+      "integrity": "sha512-wNp9ar4FfpTfQXLZWXQ/jUBBoUFOwRN/mmlv5xrhoYFpP/F5SNy7GVDMZXaBfHdUUplfJUPF5hIKQlCUR8+k3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/concave": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-7.3.4.tgz",
+      "integrity": "sha512-HZa1CV2pv4Xpcoe3t5S3ZW6j9jVbc27exzKwZWF7MlFxSz4BKRirWiME8Fku8nvQcGafpfLc+Lwpma+nGvg06w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/tin": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/convex": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-7.3.4.tgz",
+      "integrity": "sha512-zeNv0fFdOoHuOQB7nl6OLb0DyjvzDvm0e3zlFkph50GF9pEKOmkCSmlniw681aWL2aRBdWZBnON3rRzOS+9C7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "concaveman": "^1.2.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.3.4.tgz",
+      "integrity": "sha512-YxoUJwkKmTHiRFQxMQOP0tz8Vy+ga5EXl+C+F/WubjDLwT1AJu5y8CNIjLvWyjPWckj/vZG4u/1js5bx6MLADA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/difference": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-7.3.4.tgz",
+      "integrity": "sha512-kIxizNQrYLO2rtqUIeed0tPycicrXoipy/g9d4mjv91kzBEbwpyojz9zi8U9G1ISBfCEgA7wsViQD0r+8qzxXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/dissolve": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-7.3.4.tgz",
+      "integrity": "sha512-xjGY1gQ4icWhDgsW0YfU2KQtij1+ru34AfvtkVMQEgI86O9EwjW2r9Jq5DJY2PMKPbor3kz9yM/RTOiDP7f3Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/flatten": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.4.tgz",
+      "integrity": "sha512-9drWgd46uHPPyzgrcRQLgSvdS/SjVlQ6ZIBoRQagS5P2kSjUbcOXHIMeOSPwfxwlKhEtobLyr+IiR2ns1TfF8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance-weight": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/distance-weight/-/distance-weight-7.3.4.tgz",
+      "integrity": "sha512-dVMNEmIluKgn7iQTmzJJOe0UASRNmmSdFX1boAev5MISaW3AvPiURCCOV+lTIeoaQbWRpEAESbAp6JIimXFr8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/ellipse": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.3.4.tgz",
+      "integrity": "sha512-SMgbERZl12j7H8YaIofmnf0NwAvdF5Wly4tjI/eUhj/sFOKrKXOS1lvCSBJ6uSV9tFijl3ecGOVOlTpURdZ30g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/transform-rotate": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/envelope": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-7.3.4.tgz",
+      "integrity": "sha512-anXSjYMXGAyXT7rpO74VyRI0q/rPAbKE/MYvou+QvG0U/Oa7el0yF4JNNi9wKEAxXg/10aWm9kHp8s2caeLg6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/explode": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.3.4.tgz",
+      "integrity": "sha512-7QWhp3f8jhrWjvArhJ74hXBFHMaiJr/2Y1PzHCWue2/pC5MbbTV0o7peehwrrrJC/1uD6CVb3hlcb77IxtMQkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flatten": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-7.3.4.tgz",
+      "integrity": "sha512-Yt3HCh/qeNaXS4LYhXczFhBfTeaKlTBoxEw1OICb9RT3SiGU0XCxuK7H0W26OLo7XxB0qP7GPs2L3FZbiri6wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flip": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-7.3.4.tgz",
+      "integrity": "sha512-HME+kVMTyvcsYVY6dC6DTvuzq8vvDpw+C7PviEqpuT3KcVlBCoGPAqlWRdyWYOb9MDciOqNxvvJF/okpb/GQcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.4.tgz",
+      "integrity": "sha512-aDG/5mMCgKduqBwZ3XpLOdlE2hizV3fM+5dHCWyrBepCQLeM/QRvvpBDCdQKDWKpoIBmrGGYDNiOofnf3QmGhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/great-circle": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-7.3.4.tgz",
+      "integrity": "sha512-JvfzWFL9efP+xKtOnKzGvwEIXfaN0CLZoPPxNnWa/cVisLs9FVMlC9PWnuL3/3aqH5VhBHPddmU8ipzNE6KIIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "arc": "^0.2.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.4.tgz",
+      "integrity": "sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/hex-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-7.3.4.tgz",
+      "integrity": "sha512-TDCgBykFdsrP3IOOfToiiLpYkbUb3eEEhM9riIqWht0ubKUY61LN7qVs9bxZD83hG6XaDB6uY7SWkxK1zIEopQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/intersect": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/interpolate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-7.3.4.tgz",
+      "integrity": "sha512-lwYSMbHxsXYEWObv0tyBCjwTLXyfsTvOLn/NFhlsGrNCYEXn8I1VPtLGwuxbSdF3hVRgurn8qftkB1npHrNs6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/hex-grid": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/point-grid": "7.3.4",
+        "@turf/square-grid": "7.3.4",
+        "@turf/triangle-grid": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/intersect": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-7.3.4.tgz",
+      "integrity": "sha512-VsqMEMeRWWs2mjwI7sTlUgH1cEfugTGhQ0nF8ncHG7YKd9HUUTzIKpn9FJeoguPWIYITcy1ar4yJEOU/hteBVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.4.tgz",
+      "integrity": "sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isobands": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-7.3.4.tgz",
+      "integrity": "sha512-SFYefwjQdQfF0MV0zfaSwNg9J1wD7mfPP8scGcScKGM3admbwS2A3V8rqPADBfYLD2eCPBDFnySxcl9SHbPung==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.4",
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/explode": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isolines": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-7.3.4.tgz",
+      "integrity": "sha512-UFRIULkIgkZOmrhLxExWvguixbzfoCgVcXIqo2Cp68do4v+nwc3pTM7MTt4DBVFloIdX0Usrn4K44LQ/V05gxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/jsts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@turf/jsts/-/jsts-2.7.2.tgz",
+      "integrity": "sha512-zAezGlwWHPyU0zxwcX2wQY3RkRpwuoBmhhNE9HY9kWhFDkCxZ3aWK5URKwa/SWKJbj9aztO+8vtdiBA28KVJFg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "dependencies": {
+        "jsts": "2.7.1"
+      }
+    },
+    "node_modules/@turf/kinks": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.3.4.tgz",
+      "integrity": "sha512-LZTKELWxvXl0vc9ZxVgi0v07fO9+2FrZOam2B10fz/eGjy3oKNazU5gjggbnc499wEIcJS4hN+VyjQZrmsJAdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/length": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.3.4.tgz",
+      "integrity": "sha512-Dg1GnQ/B2go5NIWXt91N4L7XTjIgIWCftBSYIXkrpIM7QGjItzglek0Z5caytvb8ZRWXzZOGs8//+Q5we91WuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-arc": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-7.3.4.tgz",
+      "integrity": "sha512-nqZ+JKjDVIrvREFHgtJIP9Ps4WbWw3eStqdIzAPolrzoXyAZnpIKquyfRTxpJFYUUjDmf+uQ/SFWsPP4SOWAqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/circle": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-chunk": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-7.3.4.tgz",
+      "integrity": "sha512-xWEHR99EpUO5ZPEZhMfa0QvnFZC0W+QLxB1GcJcSeJAQ5ZMXUXY8doKF1Nztk0eppawMprEEO3nQWLvQoR4z2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/length": "7.3.4",
+        "@turf/line-slice-along": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.4.tgz",
+      "integrity": "sha512-XygbTvHa6A+v6l2ZKYtS8AAWxwmrPxKxfBbdH75uED1JvdytSLWYTKGlcU3soxd9sYb4x/g9sDvRIVyU6Lucrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-offset": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-7.3.4.tgz",
+      "integrity": "sha512-CSrg3njde9Tx+C0oL+BHUpZYpgD+PEmzp0ldDNis5ZQiTe5tUrwiIyG7A/QXf9eDnGhtV1WhCAycX0Wjged4pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-overlap": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-7.3.4.tgz",
+      "integrity": "sha512-3GBECiwNAQ2MmSwiqAHMweIl+EiePK0Jx4fXxF1KFE+NGCDv/MbGcEYfAbmsTg8mg6oRI9D8fJZzrT44DHpHXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/geojson-rbush": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "fast-deep-equal": "^3.1.3",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.4.tgz",
+      "integrity": "sha512-UeISzf/JHoWEY5yeoyvKwA5epWcvJMCpCwbIMolvfTC5pp+IVozjHPVCRvRWuzmbmAvetcW0unL5bjqi0ADmuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-7.3.4.tgz",
+      "integrity": "sha512-6Vt4Eptdr2C5T+jtpbo8D4v8b6X7KqYonPPyMB6huv+Kcg3nz4JRI9OQCDCaon9rWvU3ffWwjsjcbJCQS9o0sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice-along": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-7.3.4.tgz",
+      "integrity": "sha512-RT5HydNy8+m9Y3u39USeYZauG2EyMqCYoLnTpWcAxbZGdq9WjIwdzAwYir3d8eJkOzjlR6Khz071VM4Ufqs0Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.4.tgz",
+      "integrity": "sha512-l1zmCSUnGsiN4gf22Aw91a2VnYs5DZS67FdkYqKgr+wPEAL/gpQgIBBWSTmhwY8zb3NEqty+f/gMEe8EJAWYng==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/geojson-rbush": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@turf/truncate": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-to-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-7.3.4.tgz",
+      "integrity": "sha512-vRnDHjzwOroC74/fsJEU+dUeGhiR/B2bG0/HeEWRBplAjmwVPptRBmDGtXKTz8sbA6or17/XtOITp3zTU0lBZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/mask": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-7.3.4.tgz",
+      "integrity": "sha512-FJIlSk8m0AiqzNoLSMdYuhDRif6aeOYVdW/WxjEjpUoMalwy2w5MMlZqJB9zxt/xSrMq6lvTWJgZfZfGL2s4ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.4.tgz",
+      "integrity": "sha512-tlmw9/Hs1p2n0uoHVm1w3ugw1I6L8jv9YZrcdQa4SH5FX5UY0ATrKeIvfA55FlL//PGuYppJp+eyg/0eb4goqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/midpoint": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-7.3.4.tgz",
+      "integrity": "sha512-/XAeGvsz8l5HaqcP7TUlexzGfibqXozQgBZ8rH7az6op2Dfm3pL/Z7bKLHoVavM0ccBg0Pt7g6j9NM54kZWdKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/moran-index": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/moran-index/-/moran-index-7.3.4.tgz",
+      "integrity": "sha512-SNb16szwEG0OiyNn3z9zvSnk3M3tfwvvN8i//9UIC32APEApI+MRXCl93H/qZkKMhhh/cHA0pF0pjYZwl5z8Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance-weight": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-neighbor-analysis": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-neighbor-analysis/-/nearest-neighbor-analysis-7.3.4.tgz",
+      "integrity": "sha512-8EZlDy5poU0t7BDy8KTzOmfiGsAs2kWuB3/kgI4sMdbThKVk2P4hHKuToCSGvqAzwSy3B2qKYM1N6JeVWytu+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.4",
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-7.3.4.tgz",
+      "integrity": "sha512-WfI09f2bX0nKx/jkO7zCt3tUrJulyAlUYQtZHP7lWYMCOmZ6Pq26D6lKWjpfs2it0OHbhlx1XF/UupEUaz830w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.4.tgz",
+      "integrity": "sha512-DQrP3lRju83rIXFN68tUEpc7ki/eRwdwBkK2CTT4RAcyCxbcH2NGJPQv8dYiww/Ar77u1WLVn+aINXZH904dWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-to-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-7.3.4.tgz",
+      "integrity": "sha512-Nzp3ojQt0gDACNYG+oNWymRXAUCey0LzdiSezYtRwdA0/+FQCtuxP8Lbc8FftV10JL8D78/CRlmt7omaXLLXCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/point-to-line-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/planepoint": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-7.3.4.tgz",
+      "integrity": "sha512-KAhMAnddbuWIEZuk2bK//g+xTeKn8aV9N2AaE27x6JMJyV/wqvatIuVVqEIXI3SkAFbhiVBpVuarvPYhrJ+fhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-7.3.4.tgz",
+      "integrity": "sha512-9CL3OJ4dEt266+fxYlOQeRFqAY3XtsAuak2Gpk+K8k+Y3yGv8pvyn3QaAQ6P2npbiKt0zfG8Md/+HBAPOMPQ0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-within": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-on-feature": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-7.3.4.tgz",
+      "integrity": "sha512-tQfIxsJUxZqyO7OeJC25y3DqN9i4fmrAt4TBrPvZcIIwymgN7aMrElJKlg/dfi7JDihKp3h/CkWMjtMQA14Vwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/explode": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/nearest-point": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-7.3.4.tgz",
+      "integrity": "sha512-IdPAxlAQZj7FCZg+ObyVHlNdqwLL/oxYoQjpxMNJ511gNxokCtEv0aeRZQjYOYIxr9Ss97v3yo3ILJaF9V2kPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@turf/projection": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-polygon-distance": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-polygon-distance/-/point-to-polygon-distance-7.3.4.tgz",
+      "integrity": "sha512-VxbkgHyzCkYWSxirqSUqw+lzbYmTf2qFhVZ/T5dprhwyXWcgalpupvgRzmZmjKkgsoJ017vrvCNKZRaCCn+Z7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/point-to-line-distance": "7.3.4",
+        "@turf/polygon-to-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/points-within-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-7.3.4.tgz",
+      "integrity": "sha512-HfT83Iw99zywDfCp+nJwS+JDzH+GdNug0sut9WDjGEznHKoZyAcOk+hGKL/ja8TeCLx9VsZHOiVCQFm+NTgvgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-smooth": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-smooth/-/polygon-smooth-7.3.4.tgz",
+      "integrity": "sha512-AnpaGgNYVvP/dfz10id3AotDrUh9O+4unXCk3es1ff51VrpUhVgH3H+zyTSbVL4zAXN/ejPb8UnKCxDvNOQs4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-tangents": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-7.3.4.tgz",
+      "integrity": "sha512-D1IFocXJYF8PUMZ+BmnOstyRrzklqC86FgakYVk9O61F9Ki8LhMGaRfF+6reKMD473KvHvEf1M2EgmGt+OHDRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-within": "7.3.4",
+        "@turf/explode": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/nearest-point": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-7.3.4.tgz",
+      "integrity": "sha512-xhmOZ5rHZAKLUDLeYKWMsX84ip8CCGOcGLBHtPPYOjdIDHddMV6Sxt5kVgkmlZpK6NEWEmOD6lYR4obxHcHlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygonize": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-7.3.4.tgz",
+      "integrity": "sha512-kmj05rkJ4tE8LvbQ4GVsL5GOrRiX/F5W4RIdxo8gPGTw1Y5oLG/1vFk6Hg6x63L1WcdNtF0sq6AdEI0G9BXWXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/envelope": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.3.4.tgz",
+      "integrity": "sha512-p91zOaLmzoBHzU/2H6Ot1tOhTmAom85n1P7I4Oo0V9xU8hmJXWfNnomLFf/6rnkKDIFZkncLQIBz4iIecZ61sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/quadrat-analysis": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/quadrat-analysis/-/quadrat-analysis-7.3.4.tgz",
+      "integrity": "sha512-Yxqq8wgrDiXIX+s0uOZ2exmYfRwTIcUX8J7j4P+sbyLVbyN8W3AjN2s5ZX21P0aFf3v24FBd2fNWlm5VmMUAdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.4",
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/point-grid": "7.3.4",
+        "@turf/random": "7.3.4",
+        "@turf/square-grid": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/random": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-7.3.4.tgz",
+      "integrity": "sha512-CXMS5XDoI5x0zc1aCYbn3t603k8hjaFHNsSOvGBW20z68cwP0UwMQQr0KLqFPqI4J1O7dMX+urn8IHH27RXFYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rectangle-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rectangle-grid/-/rectangle-grid-7.3.4.tgz",
+      "integrity": "sha512-qM7vujJ4wndB4MKZlEcnUSawgvs5wXpSEFf4f+LWRIfmGhtv6serzDqFzWcmy8kF8hg5J465PMktRmAFWq/a+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-intersects": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rewind": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-7.3.4.tgz",
+      "integrity": "sha512-4BZ8MHMujl4NAT7XnIs7JoOuDhpR96oDTB0RtqTeIP4onioIedVnw1ZA3Uq08sILGpR0qKLuDsvdz4x9jtbptg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-clockwise": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-bearing": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.3.4.tgz",
+      "integrity": "sha512-tvX1toSo80q0iL0cUMMXpSKsCCfOjRqDGCmOdR6B9shhk6xP1ZM2PLQDr+MFPBFeGyQuyY4CNFkV2+3DF49vYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-destination": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.3.4.tgz",
+      "integrity": "sha512-6HikEb5nm2A18FQWk6vVLMQkc099I/7c69j47RYM27xQK8J8uBCNk1zLYyMPcZTh24xcNSbZ1iPHDsDOqw6wWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-distance": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.3.4.tgz",
+      "integrity": "sha512-phwskeijdgYMsR3qDQmytfsg2iZcp3uWK7UFc76wKTEpxozbDGFI4enX5gXvZPpyI1iD7gsktGqHsO33AjnFDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sample": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-7.3.4.tgz",
+      "integrity": "sha512-XzAATg09c2XYAXkIBbg8lktSrU1tXNjJYXtbVwF6jLp1q2wTRpwb+mZpTEPAwzZwVF81uR5c0CsdQyr5UHINVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sector": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-7.3.4.tgz",
+      "integrity": "sha512-x2tNAXl21HRcF302ghU5ohE/vmmfDcXpQKgoWHyi7o5Q9kDRBwy7kbvr5YxbT3vwW/kAWUDYM7FoXNH42bXgCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/circle": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-arc": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/shortest-path": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-7.3.4.tgz",
+      "integrity": "sha512-xbK/oM+JRL+lJCHkAdZ3QPgoivT40J9WKJ0d1Ddt8LXTpzX2YeJVgcwOZaBPG9ncZUzHfHIWS1rUjc54clnZcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/clean-coords": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/transform-scale": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/simplify": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-7.3.4.tgz",
+      "integrity": "sha512-OoSwu3vI0H9P+GzLDaOJIL9v0V8ubeP8wQjM8GeMEZrq6U2uh9JWQnAU+jviT3ODcKF5H+88snpiMik585L0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-7.3.4.tgz",
+      "integrity": "sha512-vJ+NeiEaOVsb8YiUExtyIgvH+ZybthHszl2TASZn5q340ioKHPb2JeHGlbgrB2x8pEMh3MVhoqxAbXDuND/cnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-7.3.4.tgz",
+      "integrity": "sha512-MgjlVRklQYFfQm9yJNha9kXothLPliVdeycNdmn4lWLH3SOZe1rqJPB5Z9+dhmJELT3BJraDq3W5ik5taEpKyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/rectangle-grid": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/standard-deviational-ellipse": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-7.3.4.tgz",
+      "integrity": "sha512-+BaetOKN8zA2mQCVTcRWMcfidNR3JkjmYj0r5iGRncK0J+pdxIjX2q6sF6yBMOOxMoEMy393P7j07HdBIPbibw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/center-mean": "7.3.4",
+        "@turf/ellipse": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/points-within-polygon": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tag": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-7.3.4.tgz",
+      "integrity": "sha512-ienLhLzBLeChtKhbJMmU3/vGg0hWzi6Wh/q0n39W4CmdNb+yAoGQhlYjcCbPOJT4IcdFlWE3OhbP9EmH/xPgfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tesselate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-7.3.4.tgz",
+      "integrity": "sha512-NnDgVb5ZchJEhEpq1je2hktS5UhnHMfeeumxZQgnIoMeGILpJtcOL//b/1biBBUVSJ0ZZg5zxiHdQc1PgK2gxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "earcut": "^2.2.4",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tin": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-7.3.4.tgz",
+      "integrity": "sha512-tuegrGlbKPp6Dm8r5SuYDtQ2EVzdXVVxelqI1agnzj9N+l8oTBIKLRxRbBkLsizeVIDnlmVHCQB6cRc3v+u8JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-rotate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.3.4.tgz",
+      "integrity": "sha512-pbUG6QLwyJvvitq4aAq4IQH79X8T0NmEPUGDUEEP69yW7t4+UZjDBAVbCKwpOc8gtsK0K5yvxlZ0e2CdtpNmEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-scale": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-7.3.4.tgz",
+      "integrity": "sha512-7gUIFFHaU3Ewj3rCzIu5Yo7Zjfv4R2ypjh6UWiMJnDavb7RQ8fn0AKKcNMA/vF/yxuncp2l3zoa2gygv4AKM8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-translate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-7.3.4.tgz",
+      "integrity": "sha512-qbSIEueOR8mNB7p4EB88vHvUAyuSBM8zxP68UiiTNV3Gh+OZF2VXTFiu3EFYMTaD9sE6Lxmzvv3fjW8N2q82pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/triangle-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-7.3.4.tgz",
+      "integrity": "sha512-0bki10XwYvNcPzDcSs5kUh3niOogdVeFtawJEz5FdlyTAUohbNlC+Vb40K//OqEyTrGII+q1/dE4q+1J6ZCmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/intersect": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.4.tgz",
+      "integrity": "sha512-VPXdae9+RLLM19FMrJgt7QANBikm7DxPbfp/dXgzE4Ca7v+mJ4T1fYc7gCZDaqOrWMccHKbvv4iSuW7YZWdIIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/turf": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-7.3.4.tgz",
+      "integrity": "sha512-uMAKLYt2tWJj8xIepq4vExF1r8fzJviP/5l/elDHuRyauI2mASy/Gox6kSFlrN0t0p8AT4Cs8o//4GuJTXyC+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/along": "7.3.4",
+        "@turf/angle": "7.3.4",
+        "@turf/area": "7.3.4",
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-clip": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/bearing": "7.3.4",
+        "@turf/bezier-spline": "7.3.4",
+        "@turf/boolean-clockwise": "7.3.4",
+        "@turf/boolean-concave": "7.3.4",
+        "@turf/boolean-contains": "7.3.4",
+        "@turf/boolean-crosses": "7.3.4",
+        "@turf/boolean-disjoint": "7.3.4",
+        "@turf/boolean-equal": "7.3.4",
+        "@turf/boolean-intersects": "7.3.4",
+        "@turf/boolean-overlap": "7.3.4",
+        "@turf/boolean-parallel": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/boolean-touches": "7.3.4",
+        "@turf/boolean-valid": "7.3.4",
+        "@turf/boolean-within": "7.3.4",
+        "@turf/buffer": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/center-mean": "7.3.4",
+        "@turf/center-median": "7.3.4",
+        "@turf/center-of-mass": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/circle": "7.3.4",
+        "@turf/clean-coords": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/clusters": "7.3.4",
+        "@turf/clusters-dbscan": "7.3.4",
+        "@turf/clusters-kmeans": "7.3.4",
+        "@turf/collect": "7.3.4",
+        "@turf/combine": "7.3.4",
+        "@turf/concave": "7.3.4",
+        "@turf/convex": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/difference": "7.3.4",
+        "@turf/dissolve": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/distance-weight": "7.3.4",
+        "@turf/ellipse": "7.3.4",
+        "@turf/envelope": "7.3.4",
+        "@turf/explode": "7.3.4",
+        "@turf/flatten": "7.3.4",
+        "@turf/flip": "7.3.4",
+        "@turf/geojson-rbush": "7.3.4",
+        "@turf/great-circle": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/hex-grid": "7.3.4",
+        "@turf/interpolate": "7.3.4",
+        "@turf/intersect": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/isobands": "7.3.4",
+        "@turf/isolines": "7.3.4",
+        "@turf/kinks": "7.3.4",
+        "@turf/length": "7.3.4",
+        "@turf/line-arc": "7.3.4",
+        "@turf/line-chunk": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/line-offset": "7.3.4",
+        "@turf/line-overlap": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/line-slice": "7.3.4",
+        "@turf/line-slice-along": "7.3.4",
+        "@turf/line-split": "7.3.4",
+        "@turf/line-to-polygon": "7.3.4",
+        "@turf/mask": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/midpoint": "7.3.4",
+        "@turf/moran-index": "7.3.4",
+        "@turf/nearest-neighbor-analysis": "7.3.4",
+        "@turf/nearest-point": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@turf/nearest-point-to-line": "7.3.4",
+        "@turf/planepoint": "7.3.4",
+        "@turf/point-grid": "7.3.4",
+        "@turf/point-on-feature": "7.3.4",
+        "@turf/point-to-line-distance": "7.3.4",
+        "@turf/point-to-polygon-distance": "7.3.4",
+        "@turf/points-within-polygon": "7.3.4",
+        "@turf/polygon-smooth": "7.3.4",
+        "@turf/polygon-tangents": "7.3.4",
+        "@turf/polygon-to-line": "7.3.4",
+        "@turf/polygonize": "7.3.4",
+        "@turf/projection": "7.3.4",
+        "@turf/quadrat-analysis": "7.3.4",
+        "@turf/random": "7.3.4",
+        "@turf/rectangle-grid": "7.3.4",
+        "@turf/rewind": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@turf/sample": "7.3.4",
+        "@turf/sector": "7.3.4",
+        "@turf/shortest-path": "7.3.4",
+        "@turf/simplify": "7.3.4",
+        "@turf/square": "7.3.4",
+        "@turf/square-grid": "7.3.4",
+        "@turf/standard-deviational-ellipse": "7.3.4",
+        "@turf/tag": "7.3.4",
+        "@turf/tesselate": "7.3.4",
+        "@turf/tin": "7.3.4",
+        "@turf/transform-rotate": "7.3.4",
+        "@turf/transform-scale": "7.3.4",
+        "@turf/transform-translate": "7.3.4",
+        "@turf/triangle-grid": "7.3.4",
+        "@turf/truncate": "7.3.4",
+        "@turf/union": "7.3.4",
+        "@turf/unkink-polygon": "7.3.4",
+        "@turf/voronoi": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "@types/kdbush": "^3.0.5",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/union": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-7.3.4.tgz",
+      "integrity": "sha512-JJYyPMmGcrTa9sPv2ief2QU9Hb//cEAU1zgKu/OfoCMa9a8Imp5QVm9UTAkhGlc+4qm/N/X16iJ+cvVWaxPjkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/unkink-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-7.3.4.tgz",
+      "integrity": "sha512-dFIqTLAnLL5D3OANPJtRb5OvmOM81GlNCjwgjlLQy0xdpYgKwGdE+gNXjygDrPUUXNc22xnaj3EfAfC3Pq7W4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/voronoi": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-7.3.4.tgz",
+      "integrity": "sha512-cwKSiDzDHRnA7yafQ1zOhWxRuMzp+fYFFzadCdByBAG1jAD7UlFwKhS1fjNPBNs67Fl5X3LL5ahCLW5gEdFgmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/d3-voronoi": "^1.1.12",
+        "@types/geojson": "^7946.0.10",
+        "d3-voronoi": "1.1.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -388,6 +2442,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/d3-voronoi": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
+      "integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -421,6 +2481,27 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geokdbush": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/geokdbush/-/geokdbush-1.1.5.tgz",
+      "integrity": "sha512-jIsYnXY+RQ/YCyBqeEHxYN9mh+7PqKJUJUp84wLfZ7T2kqyVPNaXwZuvf1A2uQUkrvVqEbsG94ff8jH32AlLvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/kdbush": "^1"
+      }
+    },
+    "node_modules/@types/geokdbush/node_modules/@types/kdbush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/kdbush/-/kdbush-1.0.7.tgz",
+      "integrity": "sha512-QM5iB8m/0mnGOjUKshErIZQ0LseyTieRSYc3yaOpmrRM0xbWiOuJUWlduJx+TPNK7/VFMWphUGwx3nus7eT1Wg==",
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -433,6 +2514,12 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/kdbush": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/kdbush/-/kdbush-3.0.5.tgz",
+      "integrity": "sha512-tdJz7jaWFu4nR+8b2B+CdPZ6811ighYylWsu2hpsivapzW058yP0KdfZuNY89IiRe5jbKvBGXN3LQdN2KPXVdQ==",
       "license": "MIT"
     },
     "node_modules/@types/mime": {
@@ -514,6 +2601,17 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -875,6 +2973,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/arc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/arc/-/arc-0.2.0.tgz",
+      "integrity": "sha512-8NFOo126uYKQJyXNSLY/jSklgfLQL+XWAcPXGo876JwEQ8nSOPXWNI3TV2jLZMN8QEw8uksJ1ZwS4npjBca8MA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -901,6 +3007,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1133,12 +3248,30 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concaveman": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.1.tgz",
+      "integrity": "sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==",
+      "license": "ISC",
+      "dependencies": {
+        "point-in-polygon": "^1.1.0",
+        "rbush": "^3.0.1",
+        "robust-predicates": "^2.0.4",
+        "tinyqueue": "^2.0.3"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -1213,6 +3346,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1"
+      }
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -1292,6 +3446,12 @@
       "dependencies": {
         "xtend": "^4.0.0"
       }
+    },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -1616,11 +3776,28 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -1826,6 +4003,54 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/geojson-equality-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-equality-ts/-/geojson-equality-ts-1.0.2.tgz",
+      "integrity": "sha512-h3Ryq+0mCSN/7yLs0eDgrZhvc9af23o/QuC4aTiuuzP/MRCtd6mf5rLsLRY44jX0RPUfM8c4GqERQmlUxPGPoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.14"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/geojson-polygon-self-intersections/-/geojson-polygon-self-intersections-1.2.2.tgz",
+      "integrity": "sha512-6XRNF4CsRHYmR9z5YuIk5f/aOototnDf0dgMqYGcS7y1l57ttt6MAIAxl3rXyas6lq1HEbTuLMh4PgvO+OV42w==",
+      "license": "MIT",
+      "dependencies": {
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
+      "license": "ISC"
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^1.0.1"
+      }
+    },
+    "node_modules/geokdbush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/geokdbush/-/geokdbush-2.1.0.tgz",
+      "integrity": "sha512-bMc7mu+SeUxtHwRpVvZ36qnZa/x8YAGuaPNeGDxd9bxp/jYuJ5GrUirUPz6UNiT+nn/79IQ4gCNan0y4alEUxw==",
+      "license": "ISC",
+      "dependencies": {
+        "tinyqueue": "^3.0.0"
+      }
+    },
+    "node_modules/geokdbush/node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -1964,6 +4189,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2055,6 +4289,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -2191,6 +4434,21 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -2684,6 +4942,37 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
+      "license": "MIT"
+    },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/point-in-polygon-hao/node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -2821,6 +5110,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2859,6 +5154,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -2943,6 +5247,12 @@
       "bin": {
         "rimraf": "bin.js"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
+      "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
+      "license": "Unlicense"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -3179,6 +5489,12 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==",
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3199,6 +5515,12 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "license": "BDS-3-Clause"
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -3285,6 +5607,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.2.tgz",
+      "integrity": "sha512-t6Ns52nS8LU2hqi0+rezMjFO1ZrCsCrnommXrU7Nfrg2va2dWahdvM6TuSwzdHpG29v6BHJyU1c/UWFhgVZzVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -3307,6 +5662,12 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3327,6 +5688,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-server": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
+      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "geo2topo": "bin/geo2topo"
       }
     },
     "node_modules/tree-kill": {
@@ -3462,6 +5849,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3675,6 +6068,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -8,16 +8,22 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "@turf/turf": "^7.3.4",
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.3.2",
+    "helmet": "^8.1.0",
     "pg": "^8.16.3",
-    "winston": "^3.17.0"
+    "swagger-ui-express": "^5.0.1",
+    "winston": "^3.17.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/pg": "^8.15.5",
+    "@types/swagger-ui-express": "^4.1.8",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
     "eslint": "^9.35.0",

--- a/server/src/application/health/pingDatabases.ts
+++ b/server/src/application/health/pingDatabases.ts
@@ -1,0 +1,63 @@
+import type { Pool } from "pg";
+
+export type DbDependencyId = "furnasDb" | "simaDb" | "balcarDb";
+
+export interface DbPingResult {
+  id: DbDependencyId;
+  ok: boolean;
+  latencyMs?: number;
+  error?: string;
+}
+
+export interface HealthPingSummary {
+  ok: boolean;
+  dependencies: Record<DbDependencyId, DbPingResult>;
+}
+
+/**
+ * Executa `SELECT 1` em cada pool. Falha parcial mantém `ok: false` no agregado.
+ */
+export async function pingDatabases(pools: {
+  furnas: Pool;
+  sima: Pool;
+  balcar: Pool;
+}): Promise<HealthPingSummary> {
+  const jobs: Array<{ id: DbDependencyId; pool: Pool }> = [
+    { id: "furnasDb", pool: pools.furnas },
+    { id: "simaDb", pool: pools.sima },
+    { id: "balcarDb", pool: pools.balcar },
+  ];
+
+  const results = await Promise.all(
+    jobs.map(async ({ id, pool }) => {
+      const started = Date.now();
+      try {
+        await pool.query("SELECT 1 AS ok");
+        return {
+          id,
+          ok: true,
+          latencyMs: Date.now() - started,
+        } satisfies DbPingResult;
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        return {
+          id,
+          ok: false,
+          latencyMs: Date.now() - started,
+          error: message,
+        } satisfies DbPingResult;
+      }
+    }),
+  );
+
+  const dependencies = results.reduce(
+    (acc, r) => {
+      acc[r.id] = r;
+      return acc;
+    },
+    {} as Record<DbDependencyId, DbPingResult>,
+  );
+
+  const ok = results.every((r) => r.ok);
+  return { ok, dependencies };
+}

--- a/server/src/configs/corsConfig.ts
+++ b/server/src/configs/corsConfig.ts
@@ -1,15 +1,37 @@
 import { CorsOptions } from "cors";
+import { getEnv } from "./env";
 
-const allowedOrigins = [process.env.CORS_ORIGIN || "http://localhost:3002"];
+const env = getEnv();
+
+const baseOrigins = [
+  env.CORS_ORIGIN,
+  "http://localhost:5173",
+  "http://localhost:3000",
+  "http://localhost:3001",
+  "http://localhost:3002",
+].filter(Boolean);
 
 export const corsOptions: CorsOptions = {
   origin: (origin, callback) => {
-    if (!origin || allowedOrigins.includes(origin)) {
+    if (env.CORS_ORIGIN === "*") {
       callback(null, true);
-    } else {
-      callback(new Error("Not allowed by CORS"));
+      return;
     }
+    if (!origin) {
+      callback(null, true);
+      return;
+    }
+    if (baseOrigins.includes(origin)) {
+      callback(null, true);
+      return;
+    }
+    if (origin.includes(".vercel.app")) {
+      callback(null, true);
+      return;
+    }
+    callback(new Error("Not allowed by CORS"));
   },
-  methods: ["GET"], // Apenas SELECTs
+  methods: ["GET", "POST", "OPTIONS"],
   allowedHeaders: ["Content-Type", "Authorization"],
+  credentials: true,
 };

--- a/server/src/configs/db.ts
+++ b/server/src/configs/db.ts
@@ -1,28 +1,65 @@
-import dotenv from "dotenv";
-dotenv.config();
+import { Pool, PoolConfig } from "pg";
+import type { AppEnv } from "./env";
+import { getEnv } from "./env";
 
-import { Pool } from "pg";
+function buildPoolConfig(
+  env: AppEnv,
+  host: string,
+  port: number,
+  user: string,
+  password: string,
+  database: string,
+): PoolConfig {
+  const ssl: PoolConfig["ssl"] =
+    env.DB_USE_SSL === "true" ? { rejectUnauthorized: false } : undefined;
 
-export const furnasPool = new Pool({
-  host: process.env.DB_FURNAS_HOST,
-  user: process.env.DB_FURNAS_USER,
-  password: String(process.env.DB_FURNAS_PASSWORD),
-  database: process.env.DB_FURNAS_NAME,
-  port: Number(process.env.DB_FURNAS_PORT),
-});
+  const statementTimeoutSec = Math.max(1, Math.floor(env.DB_STATEMENT_TIMEOUT_MS / 1000));
 
-export const simaPool = new Pool({
-  host: process.env.DB_SIMA_HOST,
-  user: process.env.DB_SIMA_USER,
-  password: String(process.env.DB_SIMA_PASSWORD),
-  database: process.env.DB_SIMA_NAME,
-  port: Number(process.env.DB_SIMA_PORT),
-});
+  return {
+    host,
+    port,
+    user,
+    password,
+    database,
+    ssl,
+    max: env.DB_POOL_MAX,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 10_000,
+    options: `-c statement_timeout=${statementTimeoutSec}s`,
+  };
+}
 
-export const balcarPool = new Pool({
-  host: process.env.DB_BALCAR_HOST,
-  user: process.env.DB_BALCAR_USER,
-  password: String(process.env.DB_BALCAR_PASSWORD),
-  database: process.env.DB_BALCAR_NAME,
-  port: Number(process.env.DB_BALCAR_PORT),
-});
+const env = getEnv();
+
+export const furnasPool = new Pool(
+  buildPoolConfig(
+    env,
+    env.DB_FURNAS_HOST,
+    env.DB_FURNAS_PORT,
+    env.DB_FURNAS_USER,
+    env.DB_FURNAS_PASSWORD,
+    env.DB_FURNAS_NAME,
+  ),
+);
+
+export const simaPool = new Pool(
+  buildPoolConfig(
+    env,
+    env.DB_SIMA_HOST,
+    env.DB_SIMA_PORT,
+    env.DB_SIMA_USER,
+    env.DB_SIMA_PASSWORD,
+    env.DB_SIMA_NAME,
+  ),
+);
+
+export const balcarPool = new Pool(
+  buildPoolConfig(
+    env,
+    env.DB_BALCAR_HOST,
+    env.DB_BALCAR_PORT,
+    env.DB_BALCAR_USER,
+    env.DB_BALCAR_PASSWORD,
+    env.DB_BALCAR_NAME,
+  ),
+);

--- a/server/src/configs/env.ts
+++ b/server/src/configs/env.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+  PORT: z.coerce.number().int().positive().default(3000),
+  HOST_PORT: z.coerce.number().int().optional(),
+  PAGE_SIZE: z.coerce.number().int().min(1).max(500).default(20),
+  LOG_LEVEL: z.string().default("info"),
+  CORS_ORIGIN: z.string().default("http://localhost:3002"),
+  DB_USE_SSL: z.enum(["true", "false"]).optional(),
+
+  DB_POOL_MAX: z.coerce.number().int().min(1).max(100).default(10),
+  DB_STATEMENT_TIMEOUT_MS: z.coerce.number().int().min(1000).max(300_000).default(30_000),
+
+  DB_FURNAS_HOST: z.string().min(1),
+  DB_FURNAS_PORT: z.coerce.number().int().positive(),
+  DB_FURNAS_USER: z.string().min(1),
+  DB_FURNAS_PASSWORD: z.string(),
+  DB_FURNAS_NAME: z.string().min(1),
+
+  DB_SIMA_HOST: z.string().min(1),
+  DB_SIMA_PORT: z.coerce.number().int().positive(),
+  DB_SIMA_USER: z.string().min(1),
+  DB_SIMA_PASSWORD: z.string(),
+  DB_SIMA_NAME: z.string().min(1),
+
+  DB_BALCAR_HOST: z.string().min(1),
+  DB_BALCAR_PORT: z.coerce.number().int().positive(),
+  DB_BALCAR_USER: z.string().min(1),
+  DB_BALCAR_PASSWORD: z.string(),
+  DB_BALCAR_NAME: z.string().min(1),
+});
+
+export type AppEnv = z.infer<typeof envSchema>;
+
+let cached: AppEnv | null = null;
+
+/** Valida e faz cache de `process.env`. Chamar após `dotenv.config()`. */
+export function getEnv(): AppEnv {
+  if (!cached) {
+    const parsed = envSchema.safeParse(process.env);
+    if (!parsed.success) {
+      const msg = parsed.error.flatten().fieldErrors;
+      throw new Error(`Variáveis de ambiente inválidas: ${JSON.stringify(msg)}`);
+    }
+    cached = parsed.data;
+  }
+  return cached;
+}
+
+export function resetEnvCacheForTests(): void {
+  cached = null;
+}

--- a/server/src/configs/logger.ts
+++ b/server/src/configs/logger.ts
@@ -30,6 +30,3 @@ export const logger = winston.createLogger({
     }),
   ],
 });
-/**codgo recolocado para dar commit na branch.
- * Valeu Arthurito!
- */

--- a/server/src/configs/pagination.ts
+++ b/server/src/configs/pagination.ts
@@ -1,0 +1,6 @@
+import { getEnv } from "./env";
+
+/** Tamanho de página padrão a partir de `PAGE_SIZE` (validado em `env.ts`). */
+export function getDefaultPageSize(): number {
+  return getEnv().PAGE_SIZE;
+}

--- a/server/src/controllers/balcar/fluxoinpe.controller.ts
+++ b/server/src/controllers/balcar/fluxoinpe.controller.ts
@@ -2,7 +2,9 @@ import { Request, Response } from "express";
 import { balcarPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
 
-const PAGE_SIZE = Number(process.env.PAGE_SIZE) || 10;
+import { getDefaultPageSize } from "../../configs/pagination";
+
+const PAGE_SIZE = getDefaultPageSize();
 
 export const getAll = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/server/src/controllers/balcar/reservatorio.controller.ts
+++ b/server/src/controllers/balcar/reservatorio.controller.ts
@@ -2,7 +2,9 @@ import { Request, Response } from "express";
 import { balcarPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
 
-const PAGE_SIZE = Number(process.env.PAGE_SIZE) || 10;
+import { getDefaultPageSize } from "../../configs/pagination";
+
+const PAGE_SIZE = getDefaultPageSize();
 
 export const getAll = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/server/src/controllers/data/health.controller.ts
+++ b/server/src/controllers/data/health.controller.ts
@@ -1,28 +1,28 @@
-// server/src/controllers/data/health.controller.ts
 import { Request, Response } from "express";
-import { logger } from "../../configs/logger";
+import { balcarPool, furnasPool, simaPool } from "../../configs/db";
+import { pingDatabases } from "../../application/health/pingDatabases";
 
-interface Resp  {
-  success: Boolean;
-  error?: String;
-}
+export const health = async (_req: Request, res: Response): Promise<void> => {
+  const summary = await pingDatabases({
+    furnas: furnasPool,
+    sima: simaPool,
+    balcar: balcarPool,
+  });
 
-export const health = async (req: Request, res: Response): Promise<void> => {
-  try {
-    const response : Resp = {
-      success: true
-    }
+  const uptimeSec = Math.floor(process.uptime());
+  const memory = process.memoryUsage();
 
-    res.status(200).json(response);
-  } catch (error: any) {
-    logger.error("Erro ao consultar tbfluxoinpe", {
-      message: error.message,
-      stack: error.stack,
-    });
+  const body = {
+    success: summary.ok,
+    status: summary.ok ? "ok" : "degraded",
+    uptimeSec,
+    memory: {
+      rss: memory.rss,
+      heapUsed: memory.heapUsed,
+      heapTotal: memory.heapTotal,
+    },
+    dependencies: summary.dependencies,
+  };
 
-    res.status(500).json({
-      success: false,
-      error: "Erro ao realizar a operação.",
-    });
-  }
+  res.status(summary.ok ? 200 : 503).json(body);
 };

--- a/server/src/controllers/furnas/abioticocoluna.controller.ts
+++ b/server/src/controllers/furnas/abioticocoluna.controller.ts
@@ -3,8 +3,9 @@ import { furnasPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
 import Erros from "../../utils/erros.model";
 
+import { getDefaultPageSize } from "../../configs/pagination";
 
-const PAGE_SIZE = Number(process.env.PAGE_SIZE) || 10;
+const PAGE_SIZE = getDefaultPageSize();
 
 // Interface para critérios de ordenação
 interface SortCriteria {
@@ -146,8 +147,7 @@ export const getAll = async (req: Request, res: Response): Promise<void> => {
       stack: error.stack,
     });
 
-        const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
-    
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
 
     res.status(500).json(erro);
   }

--- a/server/src/controllers/furnas/abioticosuperficie.controller.ts
+++ b/server/src/controllers/furnas/abioticosuperficie.controller.ts
@@ -3,8 +3,9 @@ import { furnasPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
 import Erros from "../../utils/erros.model";
 
+import { getDefaultPageSize } from "../../configs/pagination";
 
-const PAGE_SIZE = Number(process.env.PAGE_SIZE) || 10;
+const PAGE_SIZE = getDefaultPageSize();
 
 export const getAll = async (req: Request, res: Response): Promise<void> => {
   try {
@@ -82,8 +83,7 @@ export const getAll = async (req: Request, res: Response): Promise<void> => {
       stack: error.stack,
     });
 
-        const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
-    
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
 
     res.status(500).json(erro);
   }

--- a/server/src/controllers/furnas/bioticocoluna.controller.ts
+++ b/server/src/controllers/furnas/bioticocoluna.controller.ts
@@ -3,8 +3,9 @@ import { furnasPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
 import Erros from "../../utils/erros.model";
 
+import { getDefaultPageSize } from "../../configs/pagination";
 
-const PAGE_SIZE = Number(process.env.PAGE_SIZE) || 10;
+const PAGE_SIZE = getDefaultPageSize();
 
 export const getAll = async (req: Request, res: Response): Promise<void> => {
   try {
@@ -152,8 +153,7 @@ export const downloadCSV = async (req: Request, res: Response): Promise<void> =>
       stack: error.stack,
     });
 
-        const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
-    
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
 
     res.status(500).json(erro);
   }

--- a/server/src/controllers/furnas/campanha.controller.ts
+++ b/server/src/controllers/furnas/campanha.controller.ts
@@ -3,7 +3,6 @@ import { furnasPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
 import Erros from "../../utils/erros.model";
 
-
 export const getAll = async (req: Request, res: Response): Promise<void> => {
   try {
     // consulta com paginação
@@ -66,8 +65,7 @@ export const getAll = async (req: Request, res: Response): Promise<void> => {
       stack: error.stack,
     });
 
-    const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
-
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
 
     res.status(500).json(erro);
   }

--- a/server/src/controllers/furnas/data.controller.ts
+++ b/server/src/controllers/furnas/data.controller.ts
@@ -3,7 +3,6 @@ import { furnasPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
 import Erros from "../../utils/erros.model";
 
-
 // limite máximo de registros por página
 const MAX_LIMIT = 500;
 
@@ -484,8 +483,8 @@ export const getData = async (req: Request, res: Response): Promise<void> => {
       message: error.message,
       stack: error.stack,
     });
-        const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
-    
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
+
     res.status(500).json(erro);
   }
 };

--- a/server/src/controllers/furnas/dataByReservatorio.controller.ts
+++ b/server/src/controllers/furnas/dataByReservatorio.controller.ts
@@ -3,7 +3,6 @@ import { furnasPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
 import Erros from "../../utils/erros.model";
 
-
 /*const PAGE_SIZE = Number(process.env.PAGE_SIZE) || 10; */
 
 export const getReservatorioById = async (req: Request, res: Response): Promise<void> => {
@@ -60,8 +59,8 @@ export const getReservatorioById = async (req: Request, res: Response): Promise<
       message: error.message,
       stack: error.stack,
     });
-        const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
-    
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
+
     res.status(500).json(erro);
   }
 };

--- a/server/src/controllers/furnas/dataUnion.controller.ts
+++ b/server/src/controllers/furnas/dataUnion.controller.ts
@@ -2,9 +2,9 @@ import { Request, Response } from "express";
 import { furnasPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
 import Erros from "../../utils/erros.model";
+import { getDefaultPageSize } from "../../configs/pagination";
 
-
-const PAGE_SIZE = Number(process.env.PAGE_SIZE) || 20;
+const PAGE_SIZE = getDefaultPageSize();
 
 // 🔒 Tabelas permitidas
 const allowedTables: Record<string, string[]> = {
@@ -91,7 +91,7 @@ export const getUnionData = async (req: Request, res: Response): Promise<void> =
     });
   } catch (error: any) {
     logger.error("Erro no getUnionData", { message: error.message, stack: error.stack });
-    const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
     res.status(500).json(erro);
   }
 };

--- a/server/src/controllers/furnas/export.controller.ts
+++ b/server/src/controllers/furnas/export.controller.ts
@@ -2,7 +2,6 @@ import { Request, Response } from "express";
 import { logger } from "../../configs/logger";
 import Erros from "../../utils/erros.model";
 
-
 export const exportCSV = async (req: Request, res: Response): Promise<void> => {
   try {
     const { table } = req.query;
@@ -68,7 +67,7 @@ export const exportCSV = async (req: Request, res: Response): Promise<void> => {
       stack: error.stack,
     });
 
-    const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
 
     res.status(500).json(erro);
   }

--- a/server/src/controllers/furnas/getDataByInstituicao.ts
+++ b/server/src/controllers/furnas/getDataByInstituicao.ts
@@ -3,7 +3,6 @@ import { furnasPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
 import Erros from "../../utils/erros.model";
 
-
 export const getDataByInstituicao = async (req: Request, res: Response): Promise<void> => {
   try {
     const { table } = req.params;
@@ -79,8 +78,8 @@ export const getDataByInstituicao = async (req: Request, res: Response): Promise
       stack: error.stack,
     });
 
-    const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
-  
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
+
     res.status(500).json(erro);
   }
 };

--- a/server/src/controllers/furnas/instituicao.controller.ts
+++ b/server/src/controllers/furnas/instituicao.controller.ts
@@ -3,8 +3,9 @@ import { furnasPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
 import Erros from "../../utils/erros.model";
 
+import { getDefaultPageSize } from "../../configs/pagination";
 
-const PAGE_SIZE = Number(process.env.PAGE_SIZE) || 10;
+const PAGE_SIZE = getDefaultPageSize();
 
 // GET todas as instituições (com paginação e filtro opcional)
 export const getAll = async (req: Request, res: Response): Promise<void> => {
@@ -67,8 +68,8 @@ export const getById = async (req: Request, res: Response): Promise<void> => {
       message: error.message,
       stack: error.stack,
     });
-        const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
-    
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
+
     res.status(500).json(erro);
   }
 };

--- a/server/src/controllers/furnas/map.controller.ts
+++ b/server/src/controllers/furnas/map.controller.ts
@@ -2,7 +2,6 @@ import { Request, Response } from "express";
 import { furnasPool } from "../../configs/db";
 import Erros from "../../utils/erros.model";
 
-
 export const getMapGeoJSON = async (req: Request, res: Response): Promise<Response> => {
   try {
     const { table } = req.params;
@@ -57,7 +56,7 @@ export const getMapGeoJSON = async (req: Request, res: Response): Promise<Respon
     return res.json(geoJSON);
   } catch (error) {
     console.error("Erro no getMapGeoJSON:", error);
-    const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
     return res.status(500).json(erro);
   }
 };

--- a/server/src/controllers/furnas/reservatorio.controller.ts
+++ b/server/src/controllers/furnas/reservatorio.controller.ts
@@ -3,7 +3,9 @@ import { furnasPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
 import Erros from "../../utils/erros.model";
 
-const PAGE_SIZE = Number(process.env.PAGE_SIZE) || 10;
+import { getDefaultPageSize } from "../../configs/pagination";
+
+const PAGE_SIZE = getDefaultPageSize();
 
 export const getAll = async (req: Request, res: Response): Promise<void> => {
   try {
@@ -38,7 +40,7 @@ export const getAll = async (req: Request, res: Response): Promise<void> => {
       message: error.message,
       stack: error.stack,
     });
-    const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
 
     res.status(500).json(erro);
   }

--- a/server/src/controllers/furnas/sitio.controller.ts
+++ b/server/src/controllers/furnas/sitio.controller.ts
@@ -1,21 +1,22 @@
 import { Request, Response } from "express";
 import { furnasPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
+import { getDefaultPageSize } from "../../configs/pagination";
 
-const PAGE_SIZE = Number(process.env.PAGE_SIZE) || 10;
+const PAGE_SIZE = getDefaultPageSize();
 
-interface Resp  {
+interface Resp {
   success: Boolean;
-      page: Number;
-      limit: Number;
-      total: Number;
-      totalPages: Number;
-      data: any
+  page: Number;
+  limit: Number;
+  total: Number;
+  totalPages: Number;
+  data: any;
 }
 
 interface Erros {
   success: Boolean;
-  error: String
+  error: String;
 }
 
 export const getAll = async (req: Request, res: Response): Promise<void> => {
@@ -67,7 +68,7 @@ export const getAll = async (req: Request, res: Response): Promise<void> => {
       descricao: row.descricao,
     }));
 
-    const response : Resp = {
+    const response: Resp = {
       success: true,
       page,
       limit,
@@ -82,7 +83,7 @@ export const getAll = async (req: Request, res: Response): Promise<void> => {
       message: error.message,
       stack: error.stack,
     });
-    const erro : Erros = { success: false, error: "Erro ao realizar a operação." }
+    const erro: Erros = { success: false, error: "Erro ao realizar a operação." };
     res.status(500).json(erro);
   }
 };

--- a/server/src/controllers/polygon.controller.ts
+++ b/server/src/controllers/polygon.controller.ts
@@ -3,7 +3,7 @@
 import { Request, Response } from "express";
 import { polygonStore, Polygon } from "../data-structures/IntersectionPolygonStore";
 
-interface Resp  {
+interface Resp {
   success: Boolean;
   data: any;
   total: any;
@@ -36,13 +36,11 @@ export const criarPoligono = (req: Request, res: Response): void => {
 export const listarPoligonos = (req: Request, res: Response): void => {
   const poligonos = polygonStore.buscarTodos();
 
-  const response : Resp = {
+  const response: Resp = {
     success: true,
     data: poligonos,
-    total: polygonStore.getQuantidade()
-  }
+    total: polygonStore.getQuantidade(),
+  };
 
-  res.status(200).json(
-    response
-  );
+  res.status(200).json(response);
 };

--- a/server/src/controllers/sima/sima.controller.ts
+++ b/server/src/controllers/sima/sima.controller.ts
@@ -1,8 +1,9 @@
 import { Request, Response } from "express";
 import { simaPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
+import { getDefaultPageSize } from "../../configs/pagination";
 
-const PAGE_SIZE = Number(process.env.PAGE_SIZE) || 10;
+const PAGE_SIZE = getDefaultPageSize();
 
 // Interface para critérios de ordenação
 interface SortCriteria {

--- a/server/src/controllers/sima/simaoffline.controller.ts
+++ b/server/src/controllers/sima/simaoffline.controller.ts
@@ -1,8 +1,9 @@
 import { Request, Response } from "express";
 import { simaPool } from "../../configs/db";
 import { logger } from "../../configs/logger";
+import { getDefaultPageSize } from "../../configs/pagination";
 
-const PAGE_SIZE = Number(process.env.PAGE_SIZE) || 10;
+const PAGE_SIZE = getDefaultPageSize();
 
 export const getAll = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/server/src/data-structures/Poligono.ts
+++ b/server/src/data-structures/Poligono.ts
@@ -21,7 +21,6 @@ export default class Poligono {
     this.createdAt = new Date().toISOString();
   }
 
-
   removePointAt(index: number) {
     if (index >= 0 && index < this.points.length) this.points.splice(index, 1);
   }
@@ -36,8 +35,6 @@ export default class Poligono {
   clear() {
     this.points = [];
   }
-
-
 
   // Return a turf polygon feature (closed anel)
   toTurfPolygon() {
@@ -116,5 +113,4 @@ export default class Poligono {
   toLatLonArray() {
     return this.points.map((p) => ({ lat: Number(p.lat), lon: Number(p.lon) }));
   }
-
 }

--- a/server/src/docs/openapiSpec.ts
+++ b/server/src/docs/openapiSpec.ts
@@ -1,0 +1,59 @@
+/** Documento OpenAPI 3.0 servido em `/api-docs` (UI) e `/api-docs.json`. */
+export const openApiSpec = {
+  openapi: "3.0.3",
+  info: {
+    title: "ABP2 API",
+    version: "1.0.0",
+    description: "API do sistema de dados limnológicos (SIMA, Furnas, BALCAR).",
+  },
+  servers: [{ url: "/", description: "Servidor atual" }],
+  paths: {
+    "/health": {
+      get: {
+        summary: "Saúde da API e dos três bancos PostgreSQL",
+        tags: ["Sistema"],
+        responses: {
+          "200": {
+            description: "Todos os pools responderam",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/HealthOk" },
+              },
+            },
+          },
+          "503": {
+            description: "Um ou mais bancos indisponíveis",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/HealthDegraded" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      HealthOk: {
+        type: "object",
+        properties: {
+          success: { type: "boolean", example: true },
+          status: { type: "string", example: "ok" },
+          uptimeSec: { type: "integer" },
+          memory: { type: "object" },
+          dependencies: { type: "object" },
+        },
+      },
+      HealthDegraded: {
+        type: "object",
+        properties: {
+          success: { type: "boolean", example: false },
+          status: { type: "string", example: "degraded" },
+          uptimeSec: { type: "integer" },
+          dependencies: { type: "object" },
+        },
+      },
+    },
+  },
+} as const;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,33 +1,40 @@
-import express, { Request, Response } from "express";
 import dotenv from "dotenv";
-import router from "./routes";
-import { errorHandler } from "./middlewares/errorHandler";
-import cors from "cors";
-import { corsOptions } from "./configs/corsConfig";
-import testReservatorioRoutes from "./routes/test-reservatorio.routes";
-
-// Carrega as variáveis de ambiente definidas no arquivo .env
 dotenv.config();
 
-// Inicializa a aplicação Express
+import express, { Request, Response } from "express";
+import swaggerUi from "swagger-ui-express";
+import helmet from "helmet";
+import cors from "cors";
+import router from "./routes";
+import { errorHandler } from "./middlewares/errorHandler";
+import { corsOptions } from "./configs/corsConfig";
+import { getEnv } from "./configs/env";
+import { openApiSpec } from "./docs/openapiSpec";
+import testReservatorioRoutes from "./routes/test-reservatorio.routes";
+
+const env = getEnv();
 const app = express();
 
-// habilitar CORS
+app.use(
+  helmet({
+    contentSecurityPolicy: false,
+  }),
+);
 app.use(cors(corsOptions));
+app.use(express.json({ limit: "2mb" }));
+app.use(express.urlencoded({ extended: true, limit: "2mb" }));
 
-// Define a porta utilizada pelo servidor
-const PORT = process.env.PORT || 3000;
+app.get("/api-docs.json", (_req, res) => {
+  res.json(openApiSpec);
+});
+app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(openApiSpec as Record<string, unknown>));
 
-// Middleware para permitir o envio de dados em formato JSON no corpo das requisições
-app.use(express.json());
+if (env.NODE_ENV !== "production") {
+  app.use("/api/test-reservatorio", testReservatorioRoutes);
+}
 
-// Middleware para permitir o envio de dados em formato URL-encoded no corpo das requisições
-app.use(express.urlencoded({ extended: true }));
-
-// Rotas principais
 app.use("/", router);
 
-// Middleware para rotas não encontradas
 app.use((_req: Request, res: Response) => {
   res.status(404).json({
     success: false,
@@ -35,12 +42,10 @@ app.use((_req: Request, res: Response) => {
   });
 });
 
-app.use("/api/test-reservatorio", testReservatorioRoutes);
-
-// middleware de erro sempre por último
 app.use(errorHandler);
 
-// Inicializa o servidor na porta definida
-app.listen(PORT, function () {
-  console.log(`Servidor rodando em http://localhost:${process.env.HOST_PORT}`);
+const PORT = env.PORT;
+app.listen(PORT, () => {
+  const hostHint = env.HOST_PORT ? ` (mapeado externamente como ${env.HOST_PORT})` : "";
+  console.log(`Servidor rodando na porta ${PORT}${hostHint}`);
 });

--- a/server/src/infrastructure/http/AppError.ts
+++ b/server/src/infrastructure/http/AppError.ts
@@ -1,0 +1,12 @@
+export class AppError extends Error {
+  readonly statusCode: number;
+  readonly code?: string;
+
+  constructor(message: string, statusCode = 400, code?: string) {
+    super(message);
+    this.name = "AppError";
+    this.statusCode = statusCode;
+    this.code = code;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/server/src/middlewares/errorHandler.ts
+++ b/server/src/middlewares/errorHandler.ts
@@ -1,13 +1,32 @@
 import { Request, Response, NextFunction } from "express";
 import { logger } from "../configs/logger";
+import { AppError } from "../infrastructure/http/AppError";
 
-export function errorHandler(err: any, req: Request, res: Response, _next: NextFunction) {
+export function errorHandler(err: unknown, req: Request, res: Response, _next: NextFunction): void {
+  if (err instanceof AppError) {
+    logger.warn("Request failed", {
+      message: err.message,
+      code: err.code,
+      statusCode: err.statusCode,
+      method: req.method,
+      path: req.path,
+    });
+    res.status(err.statusCode).json({
+      success: false,
+      error: err.message,
+      ...(err.code ? { code: err.code } : {}),
+    });
+    return;
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  const stack = err instanceof Error ? err.stack : undefined;
+
   logger.error("Unhandled error", {
-    message: err.message,
-    stack: err.stack,
+    message,
+    stack,
     method: req.method,
     path: req.path,
-    body: req.body,
   });
 
   res.status(500).json({

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,22 +1,28 @@
 import express from "express";
+import rateLimit from "express-rate-limit";
 import balcar from "./balcar";
 import furnas from "./furnas";
 import sima from "./sima";
 import metadata from "./metadata";
 import tables from "./tables";
-import furnasRoutes from "./furnas";
-import simaRoutes from "./sima";
-import balcarRoutes from "./balcar";
+import { health } from "../controllers/data/health.controller";
 
 const router = express.Router();
+
+const tablesRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, error: "Muitas requisições. Tente novamente em instantes." },
+});
+
+router.get("/health", health);
 
 router.use("/balcar", balcar);
 router.use("/furnas", furnas);
 router.use("/sima", sima);
 router.use("/metadata", metadata);
-router.use("/tables", tables);
-router.use("/furnas", furnasRoutes);
-router.use("/sima", simaRoutes);
-router.use("/balcar", balcarRoutes);
+router.use("/tables", tablesRateLimit, tables);
 
 export default router;

--- a/server/src/utils/erros.model.ts
+++ b/server/src/utils/erros.model.ts
@@ -1,4 +1,4 @@
-export default  interface Erros {
+export default interface Erros {
   success: Boolean;
-  error: String
+  error: String;
 }


### PR DESCRIPTION
- Add Zod-backed env schema, optional SSL and pool/statement timeouts for pg

- Implement GET /health with parallel SELECT 1 on Furnas, SIMA and BALCAR (503 if degraded)

- Serve Swagger UI at /api-docs and spec at /api-docs.json; Helmet with CSP disabled for UI

- Rate-limit /tables; extend CORS (POST, Vercel); remove duplicate router mounts

- AppError-aware error handler; register test routes only outside production

- Centralize default page size via getDefaultPageSize(); add @turf/turf for Poligono build

- Add .env.example, .prettierignore (dist) and Prettier pass on server sources